### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/host/src/main.c
+++ b/host/src/main.c
@@ -12,6 +12,7 @@
 #ifndef __WIN32__
 #include <sys/socket.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
 #else
 #include <winsock2.h>
 typedef int socklen_t;


### PR DESCRIPTION
`sockaddr_in` is defined in netinet/in.h according to the SUS, and is required for building on FreeBSD.
